### PR TITLE
gmux support for lcd backlight

### DIFF
--- a/pommed/sysfs_backlight.c
+++ b/pommed/sysfs_backlight.c
@@ -41,6 +41,7 @@ enum {
   SYSFS_DRIVER_NVIDIA,
   SYSFS_DRIVER_RIVA,
 #else
+  SYSFS_DRIVER_GMUX,
   SYSFS_DRIVER_MBP,
   SYSFS_DRIVER_APPLE,
   SYSFS_DRIVER_NVIDIA,
@@ -64,6 +65,7 @@ static char *actual_brightness[] =
     "/sys/class/backlight/nvidiabl0/actual_brightness",
     "/sys/class/backlight/rivabl0/actual_brightness",
 #else
+    "/sys/class/backlight/gmux_backlight/actual_brightness",
     "/sys/class/backlight/mbp_backlight/actual_brightness",
     "/sys/class/backlight/apple_backlight/actual_brightness",
     "/sys/class/backlight/nvidia_backlight/actual_brightness",
@@ -82,6 +84,7 @@ static char *brightness[] =
     "/sys/class/backlight/nvidiabl0/brightness",
     "/sys/class/backlight/rivabl0/brightness",
 #else
+    "/sys/class/backlight/gmux_backlight/brightness",
     "/sys/class/backlight/mbp_backlight/brightness",
     "/sys/class/backlight/apple_backlight/brightness",
     "/sys/class/backlight/nvidia_backlight/brightness",
@@ -100,6 +103,7 @@ static char *max_brightness[] =
     "/sys/class/backlight/nvidiabl0/max_brightness",
     "/sys/class/backlight/rivabl0/max_brightness",
 #else
+    "/sys/class/backlight/gmux_backlight/brightness",
     "/sys/class/backlight/mbp_backlight/max_brightness",
     "/sys/class/backlight/apple_backlight/max_brightness",
     "/sys/class/backlight/nvidia_backlight/max_brightness",


### PR DESCRIPTION
This 'gmux' directory somewhat appeared in my mbp 5.1 on archlinux after my systemd migration
but not 100% sure when it appeared exactly
This little patch made pommed lcd backlight work again for me.
