### PR TITLE
Wrong path to sysfs node for backlight control

### DIFF
--- a/pommed/sysfs_backlight.c
+++ b/pommed/sysfs_backlight.c
@@ -103,7 +103,7 @@ static char *max_brightness[] =
     "/sys/class/backlight/nvidiabl0/max_brightness",
     "/sys/class/backlight/rivabl0/max_brightness",
 #else
-    "/sys/class/backlight/gmux_backlight/brightness",
+    "/sys/class/backlight/gmux_backlight/max_brightness",
     "/sys/class/backlight/mbp_backlight/max_brightness",
     "/sys/class/backlight/apple_backlight/max_brightness",
     "/sys/class/backlight/nvidia_backlight/max_brightness",


### PR DESCRIPTION
while trying to debug why my backlight control though the gmux driver didn't work I found this typo in that was part of the problem.

![2012-12-08-113836_601x313_scrot.png](https://f.cloud.github.com/assets/422437/1729/67cedef2-4123-11e2-8308-171f6ddbffcf.png)
