### PR TITLE
Add support for Macbook Pro Retina 2012

### DIFF
--- a/pommed/evdev.c
+++ b/pommed/evdev.c
@@ -749,6 +749,31 @@ evdev_is_wellspring5(unsigned short *id)
   return 0;
 }
 
+/* MacBookPro10,1 (15" 2012)
+ */
+static int
+evdev_is_apple_internal_keyboard(unsigned short *id)
+{
+  unsigned short product = id[ID_PRODUCT];
+
+  if (id[ID_BUS] != BUS_USB)
+    return 0;
+
+  if (id[ID_VENDOR] != USB_VENDOR_ID_APPLE)
+    return 0;
+
+  if ((product == USB_PRODUCT_ID_APPLE_INTERNAL_KEYBOARD_ANSI))
+    {
+      logdebug(" -> Apple Internal Keyboard USB assembly\n");
+
+      kbd_set_fnmode();
+
+      return 1;
+    }
+
+  return 0;
+}
+
 /* MacBookPro10,2 (13" 2012)
  */
 static int
@@ -787,6 +812,7 @@ evdev_is_internal(unsigned short *id)
 	  || evdev_is_wellspring4(id)
 	  || evdev_is_wellspring4a(id)
 	  || evdev_is_wellspring5(id)
+	  || evdev_is_apple_internal_keyboard(id)
 	  || evdev_is_wellspring6(id)
 	  || evdev_is_2011mba(id)
 	  || evdev_is_2012mba(id));

--- a/pommed/evdev.h
+++ b/pommed/evdev.h
@@ -90,9 +90,11 @@
 #define USB_PRODUCT_ID_2012MBA_JIS        0x024c
 #define USB_PRODUCT_ID_2012MBA_EUR        0x024d
 
+/* Apple Inc. Apple Internal Keyboard / Trackpad */
+#define USB_PRODUCT_ID_APPLE_INTERNAL_KEYBOARD_ANSI   0x0262
+
 /* Apple WellSpring VI keyboard + trackpad */
 #define USB_PRODUCT_ID_WELLSPRING6_ANSI   0x0259
-
 
 /* Apple external USB keyboard, white */
 #define USB_PRODUCT_ID_APPLE_EXTKBD_WHITE   0x020c

--- a/pommed/pommed.c
+++ b/pommed/pommed.c
@@ -782,7 +782,8 @@ check_machine_dmi(void)
     ret = MACHINE_MACBOOKPRO_8;
   /* MacBook Pro 13" (Late 2012)
    */
-  else if ((strcmp(buf, "MacBookPro10,2") == 0))
+  else if ((strcmp(buf, "MacBookPro10,1") == 0)
+           || (strcmp(buf, "MacBookPro10,2") == 0))
     ret = MACHINE_MACBOOKPRO_10;
   /* Core Duo MacBook (May 2006) */
   else if (strcmp(buf, "MacBook1,1") == 0)


### PR DESCRIPTION
product_name of MacBookPro10,1

Used keyboard product name reported by Pommed. Might need something
better.
