### PR TITLE
fix build for gcc-10 (-fno-common)

### DIFF
--- a/pommed/mactel/nv8600mgt_backlight.c
+++ b/pommed/mactel/nv8600mgt_backlight.c
@@ -47,9 +47,6 @@
 #include "../lcd_backlight.h"
 
 
-struct _lcd_bck_info lcd_bck_info;
-
-
 static int nv8600mgt_inited = 0;
 static unsigned int bl_port;
 

--- a/pommed/mactel/x1600_backlight.c
+++ b/pommed/mactel/x1600_backlight.c
@@ -44,8 +44,6 @@
 #include "../lcd_backlight.h"
 
 
-struct _lcd_bck_info lcd_bck_info;
-
 static int fd = -1;
 static char *memory = NULL;
 static char sysfs_resource[64];


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: mactel/nv8600mgt_backlight.o:/build/pommed-light/pommed/mactel/nv8600mgt_backlight.c:50: multiple definition of
      `lcd_bck_info'; sysfs_backlight.o:/build/pommed-light/pommed/sysfs_backlight.c:124: first defined here

The change leaves 'lcd_bck_info' definition in a single generic file.